### PR TITLE
enable retrieval of cloudant attachments, fix for error handling upon wrong credentials (cloudant in only)

### DIFF
--- a/77-cloudant-cf.js
+++ b/77-cloudant-cf.js
@@ -257,7 +257,9 @@ module.exports = function(RED) {
                 node.error(node.DBError, msg);
                 return;
             }
-            var db = node.cloudant.use(node.database);
+            //var db = node.cloudant.use(node.database);
+            var dbName = msg.payload.dbName || node.database;
+            var db = node.cloudant.use(dbName);
             var options = (typeof msg.payload === "object") ? msg.payload : {};
 
             if (node.search === "_id_") {

--- a/77-cloudant-cf.js
+++ b/77-cloudant-cf.js
@@ -223,7 +223,7 @@ module.exports = function(RED) {
 
     function CloudantInNode(n) {
         RED.nodes.createNode(this,n);
-
+		console.log("CloudantInNode new version");
         this.cloudantConfig = _getCloudantConfig(n);
         this.database       = _cleanDatabaseName(n.database, this);
         this.search         = n.search;
@@ -245,6 +245,7 @@ module.exports = function(RED) {
                 node.cloudantError = err;
             }
             else {
+				node.log("CloudantInNode connection succeeded");
                 node.cloudant = cloudant;
             }
         });
@@ -256,7 +257,8 @@ module.exports = function(RED) {
                 node.error(node.cloudantError, msg);
                 return;
             }
-            var db = cloudant.use(node.database);
+            var db = node.cloudant.use(node.database);
+
             var options = (typeof msg.payload === "object") ? msg.payload : {};
 
             if (node.search === "_id_") {


### PR DESCRIPTION
Sample usage:

[
    {
        "id": "a758667.80e2298",
        "type": "function",
        "z": "2bdd1f3.0bd0ae",
        "name": "Save msg in flow context",
        "func": "//node.log(msg._msgid);\nvar data = flow.get('data') ||{};\ndata[msg._msgid] = msg;\nflow.set('data', data);\nreturn msg;\n",
        "outputs": 1,
        "noerr": 0,
        "x": 240.14202880859375,
        "y": 30.5426025390625,
        "wires": [
            [
                "402a70fa.5ad09"
            ]
        ]
    },
    {
        "id": "402a70fa.5ad09",
        "type": "function",
        "z": "2bdd1f3.0bd0ae",
        "name": "Prepare cloudant query",
        "func": "var query = \"modelId: \" + msg.req.query.modelId;\nif (msg.req.query.docId){\n    query += \" AND docId: \" + msg.req.query.docId;\n}\nmsg.payload = {\n    query: query,\n    limit: 100 };\nnode.log(JSON.stringify(msg.payload));\nreturn msg;",
        "outputs": 1,
        "noerr": 0,
        "x": 514,
        "y": 30.545440673828125,
        "wires": [
            [
                "9b778c31.16132"
            ]
        ]
    },
    {
        "id": "9b778c31.16132",
        "type": "cloudant in",
        "z": "2bdd1f3.0bd0ae",
        "name": "modelDocs",
        "cloudant": "d6fa986a.41c028",
        "database": "documents",
        "service": "_ext_",
        "search": "_idx_",
        "design": "modelDocuments",
        "index": "modelDocs",
        "x": 765.0028381347656,
        "y": 30.710205078125,
        "wires": [
            [
                "5a412e07.12e8b"
            ]
        ]
    },
    {
        "id": "5a412e07.12e8b",
        "type": "function",
        "z": "2bdd1f3.0bd0ae",
        "name": "Prepare attachement query",
        "func": "node.log(\"msg.payload: \" + JSON.stringify(msg.payload));\nvar attachementName;\nvar contentType;\nvar originalMsg = flow.get('data')[msg._msgid];\nnode.log(\"originalMsg.req.query: \" + JSON.stringify(originalMsg.req.query));\nif (originalMsg.req.query.attachementName){\n    attachementName = originalMsg.req.query.attachementName;\n    node.log(\"attachementName from request query params: \" + attachementName);\n}else{\n    for (attachementName in msg.payload[0]._attachments){\n        node.log(\"attachementName from docs details: \" + attachementName);\n        break;\n    }    \n}\nif (originalMsg.req.query[\"content_type\"]){\n    contentType = originalMsg.req.query[\"content_type\"];\n    node.log(\"contentType from request query params: \" + contentType);\n}else{\n    contentType = msg.payload[0]._attachments[attachementName]['content_type'];\n    node.log(\"contentType from docs details: \" +  contentType);\n}\n\nvar query = { id: msg.payload[0]._id,\n    attachmentName: attachementName,\n    attachmentType: contentType\n}\nmsg.payload = query;\nnode.log(\"Cloudant query: \" + JSON.stringify(msg.payload));\nreturn msg;",
        "outputs": 1,
        "noerr": 0,
        "x": 258.04261779785156,
        "y": 232.45169067382812,
        "wires": [
            [
                "96a201ac.ebff9"
            ]
        ]
    },
    {
        "id": "96a201ac.ebff9",
        "type": "cloudant in",
        "z": "2bdd1f3.0bd0ae",
        "name": "modelDocs attachement",
        "cloudant": "d5398c36.d4f6a",
        "database": "documents",
        "service": "_ext_",
        "search": "_id_",
        "design": "modelDocuments",
        "index": "modelDocs",
        "x": 568.0426025390625,
        "y": 230.45169067382812,
        "wires": [
            [
                "4e6f126c.c1100c"
            ]
        ]
    },
    {
        "id": "4e6f126c.c1100c",
        "type": "function",
        "z": "2bdd1f3.0bd0ae",
        "name": "Prepare response",
        "func": "node.log(\"msg.headers: \" + msg.headers);\n//node.log(\"msg.payload: \" + JSON.stringify(msg.payload));\nvar data = flow.get('data');\nvar responseMsg = { \n    payload: msg.payload,\n    req: msg.req,\n    res: data[msg._msgid].res,\n    headers: msg.headers\n};\ndelete data[msg._msgid];\nflow.set('data', data);\nreturn responseMsg;",
        "outputs": 1,
        "noerr": 0,
        "x": 818.1420288085938,
        "y": 231.5426025390625,
        "wires": [
            []
        ]
    },
    {
        "id": "d6fa986a.41c028",
        "type": "cloudant",
        "z": "2bdd1f3.0bd0ae",
        "host": "",
        "name": ""
    },
    {
        "id": "d5398c36.d4f6a",
        "type": "cloudant",
        "z": "2bdd1f3.0bd0ae",
        "host": "",
        "name": ""
    }
]
