### PR TITLE
Link to search API information was broken

### DIFF
--- a/77-cloudant-cf.html
+++ b/77-cloudant-cf.html
@@ -314,7 +314,7 @@
     <p>
         to change the value of <code>limit</code>. You can find more information
         about <b>Search Index</b> parameters in the <a
-        href="https://docs.cloudant.com/api.html?http#queries" target="_blank">
+        href="https://cloud.ibm.com/apidocs/cloudant#postsearch" target="_blank">
         official Cloudant documentation</a>.
     </p>
     <p>


### PR DESCRIPTION
Added correct link to Search API information https://cloud.ibm.com/apidocs/cloudant#postsearch (vs https://docs.cloudant.com/api.html?http#queries)